### PR TITLE
Update styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 img.reaction-img {
     width: auto;
-    height: 40px;
+    height: 40px !important;
 }
 
 .reaction-item {


### PR DESCRIPTION
Reaction image heights were being overridden by Moodle's CSS. Adding !important to give the plugin's styles more power.